### PR TITLE
【fix】修复安卓端获取应用列表可能不成功的场景

### DIFF
--- a/android/app/src/main/kotlin/com/network/proxy/plugin/AppInfo.kt
+++ b/android/app/src/main/kotlin/com/network/proxy/plugin/AppInfo.kt
@@ -27,7 +27,8 @@ class AppInfo(name: CharSequence, packageName: String, icon: ByteArray, versionN
             val icon =
                 if (withIcon) drawableToByteArray(app.loadIcon(packageManager)) else ByteArray(0)
             val packageInfo = packageManager.getPackageInfo(app.packageName, 0)
-            val versionName = packageInfo.versionName
+            // 部分应用可能没有设置versionName，将导致获取列表操作失败
+            val versionName = packageInfo.versionName ?: ""
 
             return AppInfo(name, packageName, icon, versionName)
         }


### PR DESCRIPTION
安卓手机上如果安装了一个没有设置versionName的应用，可能导致获取应用列表操作crash。

运行表现：

<img width="608" alt="image" src="https://github.com/wanghongenpin/network_proxy_flutter/assets/15340677/6d7d339a-8206-40af-ac65-ec17b4e6e7bf">

debug过程错误堆栈：

<img width="1836" alt="crash" src="https://github.com/wanghongenpin/network_proxy_flutter/assets/15340677/9bcf1e44-b50c-4a3a-9f26-99dd877e45bc">

<img width="976" alt="null_version_name" src="https://github.com/wanghongenpin/network_proxy_flutter/assets/15340677/ba403292-2294-4e63-839e-aee1a69de551">

查询有类似的issue反馈：https://github.com/wanghongenpin/network_proxy_flutter/issues/151
可能是同一个原因导致。