### PR TITLE
Android应用白名单添加下拉刷新功能

### DIFF
--- a/lib/ui/mobile/setting/app_whitelist.dart
+++ b/lib/ui/mobile/setting/app_whitelist.dart
@@ -157,38 +157,45 @@ class _InstalledAppsWidgetState extends State<InstalledAppsWidget> {
           },
         ),
       ),
-      body: FutureBuilder(
-        future: apps,
-        builder: (BuildContext context, AsyncSnapshot<List<AppInfo>> snapshot) {
-          if (snapshot.hasData) {
-            List<AppInfo> appInfoList = snapshot.data!;
-            if (keyword != null && keyword!.trim().isNotEmpty) {
-              appInfoList = appInfoList
-                  .where((element) =>
-                      element.name!.toLowerCase().contains(keyword!) ||
-                      element.packageName!.toLowerCase().contains(keyword!))
-                  .toList();
-            }
-
-            return ListView.builder(
-                itemCount: appInfoList.length,
-                itemBuilder: (BuildContext context, int index) {
-                  AppInfo appInfo = appInfoList[index];
-                  return ListTile(
-                    leading: Image.memory(appInfo.icon ?? Uint8List(0)),
-                    title: Text(appInfo.name ?? ""),
-                    subtitle: Text(appInfo.packageName ?? ""),
-                    onTap: () async {
-                      Navigator.of(context).pop(appInfo.packageName);
-                    },
-                  );
-                });
-          } else {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
+      body: RefreshIndicator(
+        onRefresh: () async {
+          apps = InstalledApps.getInstalledApps(true);
+          await apps;
+          setState(() {});
         },
+        child: FutureBuilder(
+          future: apps,
+          builder: (BuildContext context, AsyncSnapshot<List<AppInfo>> snapshot) {
+            if (snapshot.hasData) {
+              List<AppInfo> appInfoList = snapshot.data!;
+              if (keyword != null && keyword!.trim().isNotEmpty) {
+                appInfoList = appInfoList
+                    .where((element) =>
+                        element.name!.toLowerCase().contains(keyword!) ||
+                        element.packageName!.toLowerCase().contains(keyword!))
+                    .toList();
+              }
+
+              return ListView.builder(
+                  itemCount: appInfoList.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    AppInfo appInfo = appInfoList[index];
+                    return ListTile(
+                      leading: Image.memory(appInfo.icon ?? Uint8List(0)),
+                      title: Text(appInfo.name ?? ""),
+                      subtitle: Text(appInfo.packageName ?? ""),
+                      onTap: () async {
+                        Navigator.of(context).pop(appInfo.packageName);
+                      },
+                    );
+                  });
+            } else {
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
在使用过程中，发现在一些机型上，首次安装时，打开应用白名单会有获取应用列表的权限提醒，此时，Andrroid会返回应用列表，但是此时只有当前应用，同意权限后，需要重启应用后才能获取到完整的应用列表。

上面的情况的原因是app_whitelist.dart 文件中的_InstalledAppsWidgetState里面的apps变量是static的，所以只会初始化一次，看到有一个issue #138  作者是想缓存应用列表。所以我在原有的基础上添加下拉刷新功能，重新拉取应用列表并赋值给apps。

![image](https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/ea297106-596d-4357-8cc0-424fb4eae851)
问题录屏：


https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/58daa9eb-96a8-4090-86ed-5db5febbb7c4


