### PR TITLE
Fix Mobile Navigator Error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:network_proxy/ui/component/multi_window.dart';
 import 'package:network_proxy/ui/configuration.dart';
 import 'package:network_proxy/ui/desktop/desktop.dart';
 import 'package:network_proxy/ui/mobile/mobile.dart';
+import 'package:network_proxy/utils/navigator.dart';
 import 'package:network_proxy/utils/platform.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -77,6 +78,7 @@ class FluentApp extends StatelessWidget {
           return MaterialApp(
             title: 'ProxyPin',
             debugShowCheckedModeBanner: false,
+            navigatorKey: navigatorHelper.navigatorKey,
             theme: appConfiguration.useMaterial3 ? material3Light : light,
             darkTheme: appConfiguration.useMaterial3 ? material3Dark : darkTheme,
             themeMode: appConfiguration.themeMode,

--- a/lib/ui/mobile/request/request.dart
+++ b/lib/ui/mobile/request/request.dart
@@ -17,6 +17,7 @@ import 'package:network_proxy/ui/mobile/request/request_editor.dart';
 import 'package:network_proxy/ui/mobile/widgets/highlight.dart';
 import 'package:network_proxy/utils/curl.dart';
 import 'package:network_proxy/utils/lang.dart';
+import 'package:network_proxy/utils/navigator.dart';
 
 ///请求行
 class RequestRow extends StatefulWidget {
@@ -92,8 +93,7 @@ class RequestRowState extends State<RequestRow> {
             Platform.isIOS ? const EdgeInsets.symmetric(horizontal: 8) : const EdgeInsets.only(left: 3, right: 5),
         onLongPress: menu,
         onTap: () {
-          Navigator.push(
-              context,
+          NavigatorHelper.push(
               MaterialPageRoute(
                   settings: const RouteSettings(name: "NetworkTabController"),
                   builder: (context) {
@@ -143,7 +143,7 @@ class RequestRowState extends State<RequestRow> {
               child: SizedBox(width: double.infinity, child: Text(localizations.repeat, textAlign: TextAlign.center)),
               onPressed: () {
                 onRepeat(widget.request);
-                Navigator.of(context).pop();
+                NavigatorHelper.pop();
               }),
           const Divider(thickness: 0.5, height: 5),
           TextButton(
@@ -155,8 +155,8 @@ class RequestRowState extends State<RequestRow> {
               child:
                   SizedBox(width: double.infinity, child: Text(localizations.editRequest, textAlign: TextAlign.center)),
               onPressed: () {
-                Navigator.of(context).pop();
-                Navigator.of(context).push(MaterialPageRoute(
+                NavigatorHelper.pop();
+                NavigatorHelper.push(MaterialPageRoute(
                     builder: (context) =>
                         MobileRequestEditor(request: widget.request, proxyServer: widget.proxyServer)));
               }),
@@ -166,7 +166,7 @@ class RequestRowState extends State<RequestRow> {
               onPressed: () {
                 FavoriteStorage.addFavorite(widget.request);
                 FlutterToastr.show(localizations.addSuccess, context);
-                Navigator.of(context).pop();
+                NavigatorHelper.pop();
               }),
           const Divider(thickness: 0.5, height: 5),
           TextButton(
@@ -174,7 +174,7 @@ class RequestRowState extends State<RequestRow> {
               onPressed: () {
                 widget.onRemove?.call(request);
                 FlutterToastr.show(localizations.deleteSuccess, context);
-                Navigator.of(context).pop();
+                NavigatorHelper.pop();
               }),
           Container(
             color: Theme.of(context).hoverColor,
@@ -187,7 +187,7 @@ class RequestRowState extends State<RequestRow> {
                 padding: const EdgeInsets.only(top: 10),
                 child: Text(localizations.cancel, textAlign: TextAlign.center)),
             onPressed: () {
-              Navigator.of(context).pop();
+              NavigatorHelper.pop();
             },
           ),
         ]);
@@ -197,8 +197,8 @@ class RequestRowState extends State<RequestRow> {
 
   //显示高级重发
   showCustomRepeat(HttpRequest request) {
-    Navigator.of(context).pop();
-    Navigator.of(context)
+    NavigatorHelper.pop();
+    NavigatorHelper
         .push(MaterialPageRoute(builder: (context) => MobileCustomRepeat(onRepeat: () => onRepeat(request))));
   }
 
@@ -218,7 +218,7 @@ class RequestRowState extends State<RequestRow> {
         onPressed: () {
           Clipboard.setData(ClipboardData(text: callback.call())).then((value) {
             FlutterToastr.show(localizations.copied, context);
-            Navigator.of(context).pop();
+            NavigatorHelper.pop();
           });
         });
   }

--- a/lib/utils/navigator.dart
+++ b/lib/utils/navigator.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class NavigatorHelper {
+  //私有构造方法
+  NavigatorHelper._internal();
+
+  factory NavigatorHelper() {
+    return _instance;
+  }
+
+  GlobalKey<NavigatorState> get navigatorKey => _navigatorKey;
+
+  BuildContext get context =>
+      NavigatorHelper().navigatorKey.currentState!.context;
+
+  static final NavigatorHelper _instance = NavigatorHelper._internal();
+
+  //保存单例
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+
+  //返回上一页
+  static void pop<T extends Object?>([T? result]) {
+    Navigator.of(NavigatorHelper().context).pop<T>(result);
+  }
+
+  //跳转到指定页面
+  static Future<T?> push<T extends Object?>(Route<T> route) {
+    return Navigator.of(NavigatorHelper().context).push(route);
+  }
+
+  //返回上一页
+  static Future<bool> maybePop<T extends Object?>( [ T? result ]) {
+    return Navigator.of(NavigatorHelper().context).maybePop<T>(result);
+  }
+}
+
+///定义全局的NavigatorHelper对象，页面引入该文件后可以直接使用
+NavigatorHelper navigatorHelper = NavigatorHelper();


### PR DESCRIPTION
使用移动端抓包的时候，当请求列表一直在刷新的时候，选择其中一个请求，长按出现弹窗，点击重放功能，发现并没有任何反应。

https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/032922e2-be98-4afc-821e-a04aad8995ba


控制台提示以下错误：
![微信截图_20240327144521](https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/efd0458d-956c-49fd-9c80-a058061f10c8)
引起报错的代码为：
![微信截图_20240327144536](https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/5ba256d6-c77e-4254-bdfa-68f24b176a97)

原因：长按请求后出现弹窗，点击重放，此时会先关闭弹窗，由于列表一直在刷新，所以可能该请求的Widget已经被销毁掉了，此时使用该Widget的Context就会报错。

解决方法：通过设置应用的navigatorKey，由navigatorKey获取应用的Context，用该Context去进行路由操作就可以避免这种现象
