### PR TITLE
Fix process icon blinking

### DIFF
--- a/lib/network/util/process_info.dart
+++ b/lib/network/util/process_info.dart
@@ -123,6 +123,10 @@ class ProcessInfo {
     return ProcessInfo(json['id'], json['name'], json['path']);
   }
 
+  bool get hasCacheIcon => icon != null || _iconCache.get(id) != null;
+
+  Uint8List? get cacheIcon => icon ?? _iconCache.get(id);
+
   Future<Uint8List> getIcon() async {
     if (icon != null) return icon!;
     if (_iconCache.get(id) != null) return _iconCache.get(id)!;

--- a/lib/ui/mobile/request/request.dart
+++ b/lib/ui/mobile/request/request.dart
@@ -112,6 +112,12 @@ class RequestRowState extends State<RequestRow> {
     if (request.processInfo == null) {
       return const Icon(Icons.question_mark, size: 38);
     }
+
+    //如果有缓存图标直接返回图标
+    if(request.processInfo!.hasCacheIcon){
+      return Image.memory(request.processInfo!.cacheIcon!, width: 40);
+    }
+
     return FutureBuilder(
         future: request.processInfo!.getIcon(),
         builder: (BuildContext context, AsyncSnapshot<Uint8List> snapshot) {


### PR DESCRIPTION
在全部请求列表中，进行搜索，每次输入文本，应用图标都会闪烁一次
演示视频：


https://github.com/wanghongenpin/network_proxy_flutter/assets/31216074/6cf34e53-6e1d-490d-a737-af514a7301e9



优化措施：
在加载时，判断如果存在icon的缓存，则直接返回Image，否则返回FutureBuilder。



