### PR TITLE
[fix]重写规则的url匹配，支持url中带参数的场景

### DIFF
--- a/lib/network/components/request_rewrite_manager.dart
+++ b/lib/network/components/request_rewrite_manager.dart
@@ -485,7 +485,7 @@ class RequestRewriteRule {
   String? rewritePath;
 
   RequestRewriteRule({this.enabled = true, this.name, required this.url, required this.type, this.rewritePath})
-      : _urlReg = RegExp(url.replaceAll("*", ".*"));
+      : _urlReg = RegExp(url.replaceAll("*", ".*").replaceAll('?', '\\?'));
 
   bool match(String url, {RuleType? type}) {
     return enabled && (type == null || this.type == type) && _urlReg.hasMatch(url);


### PR DESCRIPTION
<img width="608" alt="企业微信截图_efa60a19-d537-4056-900a-385052a00bd4" src="https://github.com/wanghongenpin/network_proxy_flutter/assets/15340677/04bd2a9e-5b91-403a-8e05-88601ad67981">

请求重写的规则中，如果在url中带了参数字段，则无法匹配成功。

调试发现是生成的正则中的?需要转义，尝试修改了下匹配的正则生成逻辑。
