### PR TITLE
updateQueryParam重写规则兼容=号

### DIFF
--- a/lib/network/components/request_rewrite_manager.dart
+++ b/lib/network/components/request_rewrite_manager.dart
@@ -306,12 +306,16 @@ class RequestRewrites {
           queryParameters.remove(item.value);
           break;
         case RewriteType.updateQueryParam:
-          var pair = item.key?.split("=");
-          var val = queryParameters[pair!.first];
-          if (val != null && RegExp(pair.last).hasMatch(val)) {
-            var split = item.value?.split("=");
-            queryParameters.remove(pair.first);
-            queryParameters[split!.first] = split.last;
+          var itemKeySplitIdx = item.key?.indexOf('=');
+          var itemKeyK = item.key?.substring(0, itemKeySplitIdx);
+          var itemKeyV = item.key?.substring(itemKeySplitIdx + 1);
+          var val = queryParameters[itemKeyK];
+          if (val != null && RegExp(itemKeyV).hasMatch(val)) {
+            var itemValueSplitIdx = item.key?.indexOf('=');
+            var itemValueK = item.key?.substring(0, itemValueSplitIdx);
+            var itemValueV = item.key?.substring(itemValueSplitIdx + 1);
+            queryParameters.remove(itemKeyK);
+            queryParameters[itemValueK] = itemValueV;
           }
           break;
         default:


### PR DESCRIPTION
目前规则不能重写queryparam带有=号的情况，如：
`name=adeb==`
无编译环境，故未测试，劳烦作者审阅。